### PR TITLE
NOT WORK: Fixed runtime crash in expo 51 based on react native 0.74.5

### DIFF
--- a/ActionButton.js
+++ b/ActionButton.js
@@ -338,7 +338,7 @@ ActionButton.propTypes = {
   bgColor: PropTypes.string,
   bgOpacity: PropTypes.number,
   buttonColor: PropTypes.string,
-  buttonTextStyle: Text.propTypes.style,
+  buttonTextStyle: Text?.propTypes?.style,
   buttonText: PropTypes.string,
 
   offsetX: PropTypes.number,


### PR DESCRIPTION
- Added null safety so if any value is missing than it won't break the flow and crashes, Instead it will not take the value.

Reproducing steps:
- Install this library in any of expo project running on expo 51, react native 0.74.5
- Run the App
- When app installed and bundled it throws below attached crash.

![Screenshot_1732525937](https://github.com/user-attachments/assets/2e8430bf-c25a-4267-befe-d510b37df65f)
